### PR TITLE
fix: knowage-main service requires wrong secret

### DIFF
--- a/charts/knowage/templates/deployment.yaml
+++ b/charts/knowage/templates/deployment.yaml
@@ -368,7 +368,7 @@ spec:
               path: extContext
       - name: tls
         secret:
-          secretName: {{ include "knowage.tls.proxy.name" . }}
+          secretName: {{ include "knowage.tls.main.name" . }}
           items:
             - key: tls.crt
               path: certificate.crt


### PR DESCRIPTION
knowage-main fails to start if deployCustomReverseProxy is false because it requires wrong secret